### PR TITLE
Beheer: geen highlight bij mermaid diagrammen

### DIFF
--- a/js/config.mjs
+++ b/js/config.mjs
@@ -42,9 +42,12 @@ loadRespecWithConfiguration({
           generatedFigures.push(figure);
         }
       }
-      mermaid.run({
+      await mermaid.run({
         nodes: generatedFigures,
       });
+      for (const figure of generatedFigures) {
+        figure.classList.remove('hljs');
+      }
     }
   ]
 


### PR DESCRIPTION
We halen expliciet de `.hljs` class weg van de diagrammen.